### PR TITLE
support upgraded death charge that restores spec energy twice

### DIFF
--- a/src/main/java/com/infernostats/DeathChargeReminderPlugin.java
+++ b/src/main/java/com/infernostats/DeathChargeReminderPlugin.java
@@ -39,6 +39,8 @@ public class DeathChargeReminderPlugin extends Plugin
 	public static final Pattern DEATH_CHARGE_ACTIVE =
 		Pattern.compile("<col=[A-Fa-f\\d]+>Upon the death of your next foe, some of your special attack energy will be restored\\.</col>");
 
+	public static final Pattern UPGRADED_DEATH_CHARGE_ACTIVE =
+		Pattern.compile("<col=[A-Fa-f\\d]+>Upon the death of your next two foes, some of your special attack energy will be restored\\.</col>");
 
 	@Override
 	protected void startUp()
@@ -65,7 +67,7 @@ public class DeathChargeReminderPlugin extends Plugin
 	{
 		final String message = event.getMessage();
 
-		if (message.matches(DEATH_CHARGE_ACTIVE.pattern()))
+		if (message.matches(DEATH_CHARGE_ACTIVE.pattern()) || message.matches(UPGRADED_DEATH_CHARGE_ACTIVE.pattern()))
 		{
 			timer.start();
 		}


### PR DESCRIPTION
Death Charge can be upgraded with a [rite of vile transference](https://oldschool.runescape.wiki/w/Rite_of_vile_transference), available as a drop from [Yama](https://oldschool.runescape.wiki/w/Yama). With this upgrade, special attack energy will be restored for two kills per cast, rather than just one.